### PR TITLE
v. 0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,14 @@
+# ChangeLog
+
+## v. 0.2.0
+ * Add `languages` config parameter
+ * Accept overall language definition (a) in config (b) as a plugin argument
+ * Cache Presidio AnalyzerEngine to reuse it if another task object is created
+ * Ensure that a custom config can delete a PII defined in the standard config
+   (by setting its `lang` to `null`)
+
+## v. 0.1.1
+ * improved debug output
+
+## v. 0.1.0
+ * initial version

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,5 @@
+v. 0.1.1
+ * improved debug output
+
+v. 0.1.0
+ * initial version

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,0 @@
-v. 0.1.1
- * improved debug output
-
-v. 0.1.0
- * initial version

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Pii Extractor plugin: Presidio
 
+[![version](https://img.shields.io/pypi/v/pii-extract-plg-presidio)](https://pypi.org/project/pii-extract-plg-presidio)
+[![changelog](https://img.shields.io/badge/change-log-blue)](CHANGES.md)
+[![license](https://img.shields.io/pypi/l/pii-extract-plg-presidio)](LICENSE)
+[![build status](https://github.com/piisa/pii-extract-plg-presidio/actions/workflows/pii-extract-plg-presidio-pr.yml/badge.svg)](https://github.com/piisa/pii-extract-plg-presidio/actions)
+
 This repository builds a Python package that installs a [pii-extract-base]
 plugin to perform PII detection for text data using the Microsoft [Presidio]
 Python library.
+
+The name of the plugin entry point is `piisa-detectors-presidio`
 
 
 ## Requirements
@@ -44,8 +51,13 @@ and thus its functionality is exposed to it.
 The plugin is governed by a PIISA configuration file; there is one [default
 file] included in the package resources. The format tag for the configuration
 is `"piisa:config:extract-plg-presidio:main:v1`, and it has two sections:
- * `nlp_config` defines the NLP engine to be used, and the available models
-   (per language)
+ * `reuse_engine`: build the engine only once, and reuse it if another task
+   object is created (default is `True`)
+ * `nlp_config` defines Presidio initialization arguments
+     - `languages`: the languages to initialize Presidio with
+	 - `nlp_engine_name`: the NLP engine to be used
+	 - `models`: a list of NLP models to be loaded (each item contains 
+	    `lang_code` and `model_name`), and the available models
  * `pii_list` defines the PIISA instances to be detected. It contains a list
    of standard [pii task descriptors]; each one has an additional `extra`
    field that contains the Presidio PII entity to be mapped to the descriptor.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ regex >= 2021.11.10
 
 presidio_analyzer >= 2.2.30
 
-pii-data >= 0.2.0, <1.0.0
-pii-extract-base >= 0.2.0, <1.0.0
+pii-data >= 0.3.2, <1.0.0
+pii-extract-base >= 0.3.1, <1.0.0

--- a/src/pii_extract_plg_presidio/__init__.py
+++ b/src/pii_extract_plg_presidio/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.0"
+VERSION = "0.1.1"

--- a/src/pii_extract_plg_presidio/__init__.py
+++ b/src/pii_extract_plg_presidio/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.1"
+VERSION = "0.2.0"

--- a/src/pii_extract_plg_presidio/analyzer.py
+++ b/src/pii_extract_plg_presidio/analyzer.py
@@ -14,6 +14,10 @@ from presidio_analyzer import AnalyzerEngine
 from . import defs
 
 
+# Cache for engine reuse
+ENGINE_CACHE = {}
+
+
 def presidio_version() -> str:
     """
     Return the version of the Presidio package
@@ -21,28 +25,51 @@ def presidio_version() -> str:
     return version("presidio_analyzer")
 
 
-def presidio_analyzer(config: Dict, lang: List[str],
+def presidio_analyzer(config: Dict,
                       logger: PiiLogger = None) -> AnalyzerEngine:
     """
-    Create a Presidio AnalyzerEngine object
+    Create a Presidio AnalyzerEngine object.
+    Will reuse an object with the same configuration if it's in the cache
+    and `reuse_engine` is True (which is its default value)
     """
-
     # Fetch NLP engine configuration. Keep only the language models we'll use
-    langset = set(lang) if lang else None
     eng = config.get(defs.CFG_ENGINE)
+    lang = eng.get("languages", [])
+    if isinstance(lang, str):
+        lang = [lang]
+    langset = set(lang)
     nlp_config = {
         "nlp_engine_name": eng.get("nlp_engine_name"),
         "models": [m for m in eng.get("models")
                    if not langset or m["lang_code"] in langset]
     }
+
     if logger:
         logger(".. Presidio NLP engine: %s", nlp_config.get("nlp_engine_name"))
         logger(".. Presidio NLP models: %s", nlp_config.get("models"))
 
+    # Reuse engine if it has the same parameters
+    reuse = config.get(defs.CFG_REUSE, True)
+    if reuse:
+        key_l = "-".join(sorted(lang)) if lang else "-"
+        key_m = (m["lang_code"] + ":" + m["model_name"]
+                 for m in nlp_config["models"])
+        key = [key_l, nlp_config['nlp_engine_name'], '-'.join(sorted(key_m))]
+        key = '/'.join(key)
+        engine = ENGINE_CACHE.get(key)
+        if key in ENGINE_CACHE:
+            logger(".. Reusing Presidio NLP engine")
+            return engine
+
+
     # Create an NLP engine, according to the configuration
+    logger(".. Creating Presidio NLP engine")
     provider = NlpEngineProvider(nlp_configuration=nlp_config)
     nlp_engine = provider.create_engine()
 
     # Set up the Presidio Analyzer engine
-    return AnalyzerEngine(supported_languages=lang or None,
-                          nlp_engine=nlp_engine, **config[defs.CFG_PARAMS])
+    engine = AnalyzerEngine(supported_languages=lang or None,
+                            nlp_engine=nlp_engine, **config[defs.CFG_PARAMS])
+    if reuse:
+        ENGINE_CACHE[key] = engine
+    return engine

--- a/src/pii_extract_plg_presidio/defs.py
+++ b/src/pii_extract_plg_presidio/defs.py
@@ -3,9 +3,10 @@
 FMT_CONFIG = "pii-extract-plg-presidio:main:v1"
 
 # Elements in plugin configuration
-CFG_MAP = "pii_list"
+CFG_REUSE = "reuse_engine"
 CFG_ENGINE = "nlp_config"
 CFG_PARAMS = "analyzer_params"
+CFG_MAP = "pii_list"
 
 # Default values for task info
 TASK_SOURCE = "piisa:pii-extract-plg-presidio"

--- a/src/pii_extract_plg_presidio/plugin_loader.py
+++ b/src/pii_extract_plg_presidio/plugin_loader.py
@@ -61,7 +61,7 @@ class PiiExtractPluginLoader:
 
 
     def __repr__(self) -> str:
-        return '<PiiExtractPluginLoader: presidio>'
+        return f'<PiiExtractPluginLoader: presidio {VERSION}>'
 
 
     def get_plugin_tasks(self, lang: str = None) -> Iterable[Dict]:

--- a/src/pii_extract_plg_presidio/plugin_loader.py
+++ b/src/pii_extract_plg_presidio/plugin_loader.py
@@ -4,7 +4,7 @@ The plugin entry point
 
 from pathlib import Path
 
-from typing import Dict, Iterable, Union
+from typing import Dict, Iterable, Union, List
 
 from pii_data.helper.exception import ConfigException
 from pii_data.helper.config import load_single_config
@@ -13,8 +13,8 @@ from pii_extract.build.collection.task_collection import ensure_enum
 from . import VERSION, defs
 from .task import PresidioTaskCollector
 
-
-CFG_ELEM = defs.CFG_MAP, defs.CFG_ENGINE, defs.CFG_PARAMS
+# Elements in the PIISA presidio config to read
+CFG_ELEM = defs.CFG_REUSE, defs.CFG_ENGINE, defs.CFG_PARAMS, defs.CFG_MAP
 
 
 def load_presidio_plugin_config(config: Union[Dict, str] = None) -> Dict:
@@ -50,14 +50,16 @@ class PiiExtractPluginLoader:
 
 
     def __init__(self, config: Union[str, Dict] = None, debug: bool = False,
-                 **kwargs):
+                 languages: List[str] = None, **kwargs):
         """
           :param config: either a configuration for the plugin, or a filename
             containing that configuration
           :param debug: activate debug mode
+          :param languages: languages to load in the Presidio analyzer engine
         """
         self.cfg = load_presidio_plugin_config(config)
-        self.obj = PresidioTaskCollector(self.cfg, debug=debug)
+        self.obj = PresidioTaskCollector(self.cfg, languages=languages,
+                                         debug=debug)
 
 
     def __repr__(self) -> str:

--- a/src/pii_extract_plg_presidio/resources/plugin-config.json
+++ b/src/pii_extract_plg_presidio/resources/plugin-config.json
@@ -1,6 +1,7 @@
 {
   "format": "piisa:config:pii-extract-plg-presidio:main:v1",
   "nlp_config": {
+    "languages": ["en", "es"],
     "nlp_engine_name": "spacy",
     "models": [
       {"lang_code": "en", "model_name": "en_core_web_lg"},

--- a/src/pii_extract_plg_presidio/task.py
+++ b/src/pii_extract_plg_presidio/task.py
@@ -52,12 +52,12 @@ class PresidioTask(BaseMultiPiiTask):
                  cfg: Dict, log: PiiLogger, **kwargs):
         """
           :param task: the PII task info dict
-          :param pii: the list of PII entities to include
+          :param pii: the list of descriptors for the PII entities to include
           :param cfg: the plugin congiguration
           :param log: a logger object
         """
-        # Use the "extra" field to build the map of Presidio entities to
-        # PIISA entities (by language)
+        # Use the "extra" field in each PII descriptor to build the map of
+        # Presidio entities to PIISA entities (by language)
         self.ent_map = defaultdict(dict)
         if isinstance(pii, dict):
             pii = [pii]
@@ -72,7 +72,8 @@ class PresidioTask(BaseMultiPiiTask):
         # Decide is the default language (if we have a single one)
         all_lang = union_sets(taskd_field(t, "lang") for t in pii)
         self.lang = all_lang[0] if len(all_lang) == 1 else None
-        self._log(".. PresidioTask: lang=%s tasks=#%d", self.lang, len(pii), )
+        self._log(".. PresidioTask (%s): lang=%s tasks=#%d", VERSION,
+                  self.lang, len(pii))
 
         # Set up the Presidio Analyzer engine
         try:

--- a/test/taux/monkey_patch.py
+++ b/test/taux/monkey_patch.py
@@ -77,11 +77,16 @@ def patch_presidio_analyzer(monkeypatch, results: Dict,
     monkeypatch.setattr(mod_an, 'NlpEngineProvider',
                         Mock(return_value=engine_provider))
 
-    # Patch AnalyzerEngine
+    # Create an instance of an analyzer engine mock
     mock_analyzer = AnalyzerEngineMock(results,
                                        entities=pres_entities or PRESIDIO_ENT,
                                        recognizers=pres_recognizers)
+
+    # Patch AnalyzerEngine class
     mock_class = Mock(return_value=mock_analyzer)
     monkeypatch.setattr(mod_an, 'AnalyzerEngine', mock_class)
 
-    return mock_analyzer
+    # Reset cache
+    monkeypatch.setattr(mod_an, 'ENGINE_CACHE', {})
+
+    return mock_class

--- a/test/unit/test_A_plugin.py
+++ b/test/unit/test_A_plugin.py
@@ -4,6 +4,7 @@ Test the plugin loader mechanics
 
 from pii_data.types import PiiEnum
 
+from pii_extract_plg_presidio import VERSION
 from pii_extract_plg_presidio.task import PresidioTask
 import pii_extract_plg_presidio.plugin_loader as mod
 
@@ -13,7 +14,7 @@ def test10_constructor():
     Test basic construction
     """
     ep = mod.PiiExtractPluginLoader()
-    assert str(ep) == '<PiiExtractPluginLoader: presidio>'
+    assert str(ep) == f'<PiiExtractPluginLoader: presidio {VERSION}>'
 
 
 def test20_tasklist():

--- a/test/unit/test_B_plugin_collector.py
+++ b/test/unit/test_B_plugin_collector.py
@@ -41,7 +41,7 @@ def test20_task_obj(monkeypatch):
     tdef = t["obj"]
     assert tdef["class"] == "piitask"
     assert tdef["task"] == PresidioTask
-    assert sorted(tdef["kwargs"].keys()) == ["cfg", "log"]
+    assert sorted(tdef["kwargs"].keys()) == ["all_lang", "cfg", "log"]
 
 
 def test30_task_pii(monkeypatch):

--- a/test/unit/test_C_detector.py
+++ b/test/unit/test_C_detector.py
@@ -8,7 +8,6 @@ from pii_extract.build.collection import get_task_collection
 
 from taux.monkey_patch import patch_entry_points, patch_presidio_analyzer
 
-
 # ---------------------------------------------------------------------------
 
 
@@ -38,3 +37,27 @@ def test11_tasklist_lang(monkeypatch):
     tasks = list(tasks)
     assert len(tasks) == 1
     assert str(tasks[0]) == "<PresidioTask #4>"
+
+
+def test12_engine_cache(monkeypatch):
+    """
+    Check engine object reuse
+    """
+    patch_entry_points(monkeypatch)
+    mck = patch_presidio_analyzer(monkeypatch, {})
+
+    piic = get_task_collection(debug=False)
+
+    # Build once
+    tasks = piic.build_tasks("en")
+    tasks = list(tasks)
+
+    # Check the constructor was called
+    assert mck.call_count == 1
+
+    # Build again -- analyzer will be called, but reuse the object
+    tasks = piic.build_tasks("es")
+    tasks = list(tasks)
+
+    # Check no new calls to the constructor
+    assert mck.call_count == 1

--- a/test/unit/test_D_process.py
+++ b/test/unit/test_D_process.py
@@ -6,8 +6,11 @@ import pytest
 
 from pii_extract.build.collection import get_task_collection
 
+import pii_extract_plg_presidio.analyzer as anmod
+
 from taux.monkey_patch import patch_entry_points, patch_presidio_analyzer
 from taux.taskproc import process_tasks
+
 
 
 TESTCASES = [
@@ -42,8 +45,8 @@ def test20_detect(monkeypatch):
     Check detection
     """
     results = {t[0]: t[1] for t in TESTCASES}
-    patch_presidio_analyzer(monkeypatch, results)
     patch_entry_points(monkeypatch)
+    patch_presidio_analyzer(monkeypatch, results)
 
     piic = get_task_collection()
     tasks = piic.build_tasks("en")


### PR DESCRIPTION
 * Add `languages` config parameter
 * Accept overall language definition (a) in config (b) as a plugin argument
 * Cache Presidio AnalyzerEngine to reuse it if another task object is created
 * Ensure that a custom config can delete a PII defined in the standard config (by setting its `lang` to `null`)
 * improved debug output

